### PR TITLE
Assets

### DIFF
--- a/app/extensions/auth/security.py
+++ b/app/extensions/auth/security.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+Security component
+
+Provides access to the werkzeug security python utils to generate random strings with extra helpers
+"""
+
+from werkzeug import security
+
+# A random string with length determined by parameter
+def generate_random(length):
+    return security.gen_salt(length)
+
+def generate_random_64():
+    return generate_random(64)
+
+def generate_random_128():
+    return generate_random(128)

--- a/app/modules/auth/models.py
+++ b/app/modules/auth/models.py
@@ -85,7 +85,6 @@ CODE_SETTINGS = {
 }
 
 
-
 class OAuth2Client(db.Model):
     """
     Model that binds OAuth2 Client ID and Secret to a specific User.

--- a/app/modules/auth/models.py
+++ b/app/modules/auth/models.py
@@ -14,9 +14,9 @@ import enum
 
 from sqlalchemy import or_
 from sqlalchemy_utils.types import ScalarListType
-from werkzeug import security
 
 from app.extensions import db, HoustonModel
+from app.extensions.auth import security
 from app.modules.users.models import User
 
 import datetime
@@ -85,17 +85,6 @@ CODE_SETTINGS = {
 }
 
 
-def _generate_salt(length):
-    return security.gen_salt(length)
-
-
-def _generate_salt_64(*args, **kwargs):
-    return _generate_salt(64)
-
-
-def _generate_salt_128(*args, **kwargs):
-    return _generate_salt(128)
-
 
 class OAuth2Client(db.Model):
     """
@@ -105,7 +94,7 @@ class OAuth2Client(db.Model):
     __tablename__ = 'oauth2_client'
 
     guid = db.Column(db.GUID, default=uuid.uuid4, primary_key=True)
-    secret = db.Column(db.String(length=64), default=_generate_salt_64, nullable=False)
+    secret = db.Column(db.String(length=64), default=security.generate_random_64, nullable=False)
 
     user_guid = db.Column(
         db.ForeignKey('user.guid', ondelete='CASCADE'), index=True, nullable=False
@@ -234,10 +223,10 @@ class OAuth2Token(db.Model):
     token_type = db.Column(db.Enum(TokenTypes), nullable=False)
 
     access_token = db.Column(
-        db.String(length=128), default=_generate_salt_128, unique=True, nullable=False
+        db.String(length=128), default=security.generate_random_128, unique=True, nullable=False
     )
     refresh_token = db.Column(
-        db.String(length=128), default=_generate_salt_128, unique=True, nullable=True
+        db.String(length=128), default=security.generate_random_128, unique=True, nullable=True
     )
     expires = db.Column(db.DateTime, nullable=False)
     scopes = db.Column(ScalarListType(separator=' '), nullable=False)

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -140,6 +140,11 @@ class User(db.Model, FeatherModel, UserEDMMixin):
       complete
     """
 
+    def __init__(self, *args, **kwargs):
+        if 'password' not in kwargs:
+            raise ValueError("User must have a password")
+        super().__init__(*args, **kwargs)
+
     guid = db.Column(
         db.GUID, default=uuid.uuid4, primary_key=True
     )  # pylint: disable=invalid-name
@@ -369,7 +374,7 @@ class User(db.Model, FeatherModel, UserEDMMixin):
 
         return self.get_codes(CodeTypes.recover, replace=True, replace_ttl=None)
 
-    def set_password(self, password=None):
+    def set_password(self, password):
         if password is None:
             # This function "sets" the password, it's the responsibility of the caller to ensure it's valid
             raise ValueError("Empty password not allowed")

--- a/app/modules/users/parameters.py
+++ b/app/modules/users/parameters.py
@@ -38,7 +38,7 @@ class CreateUserParameters(Parameters, schemas.BaseUserSchema):
     """
 
     email = base_fields.Email(description='Example: root@gmail.com', required=True)
-    password = base_fields.String(description='No rules yet', required=False)
+    password = base_fields.String(description='No rules yet', required=True)
 
     recaptcha_key = base_fields.String(
         description=(

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -95,7 +95,6 @@ class Users(Resource):
         """
         Create a new user.
         """
-        from app.modules.auth.models import _generate_salt
 
         email = args.get('email', None)
         user = User.query.filter_by(email=email).first()
@@ -106,7 +105,7 @@ class Users(Resource):
             )
 
         if 'password' not in args:
-            args['password'] = _generate_salt(128)
+            abort(code=HTTPStatus.BAD_REQUEST, message='Must provide a password')
 
         args['is_active'] = True
 

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -90,6 +90,7 @@ class Users(Resource):
     @api.response(schemas.DetailedUserSchema())
     @api.response(code=HTTPStatus.FORBIDDEN)
     @api.response(code=HTTPStatus.CONFLICT)
+    @api.response(code=HTTPStatus.BAD_REQUEST)
     @api.doc(id='create_user')
     def post(self, args):
         """

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -56,6 +56,5 @@ utool
 webargs==5.5.2
 werkzeug>=0.15,<0.16
 wheel
-xkcdpass
 
 xxhash

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -130,3 +130,15 @@ def test_new_user_creation_duplicate_must_fail(flask_app_client, db):
     user1_instance = User.query.get(user_guid)
     with db.session.begin():
         db.session.delete(user1_instance)
+
+def test_new_user_creation_no_password_must_fail(flask_app_client):
+    # pylint: disable=invalid-name
+    response = create_new_user(
+        flask_app_client,
+        data={'email': 'user1@localhost'},
+        must_succeed=False,
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/json'
+    assert set(response.json.keys()) >= {'status', 'message'}

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -139,6 +139,6 @@ def test_new_user_creation_no_password_must_fail(flask_app_client):
         must_succeed=False,
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 422
     assert response.content_type == 'application/json'
     assert set(response.json.keys()) >= {'status', 'message'}

--- a/tests/modules/users/test_models.py
+++ b/tests/modules/users/test_models.py
@@ -4,6 +4,7 @@
 import pytest
 
 from app.modules.users import models
+from tests import utils
 
 
 def test_User_repr(user_instance):
@@ -82,7 +83,9 @@ def test_User_static_roles_setting(
 
 def test_User_check_owner(user_instance):
     assert user_instance.check_owner(user_instance)
-    assert not user_instance.check_owner(models.User())
+
+    second_user = utils.generate_user_instance()
+    assert not user_instance.check_owner(second_user)
 
 
 def test_User_find_with_password(
@@ -111,3 +114,9 @@ def test_User_find_with_password(
     with db.session.begin():
         db.session.delete(user1)
         db.session.delete(user2)
+
+
+def test_User_must_have_password():
+    with pytest.raises(ValueError, match="User must have a password"):
+        user = models.User(email='user1@localhost', full_name='Lord Lucan')
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,8 +11,7 @@ import json
 from flask import Response
 from flask.testing import FlaskClient
 from werkzeug.utils import cached_property
-
-from app.modules.auth.models import _generate_salt
+from app.extensions.auth import security
 
 import uuid
 
@@ -125,7 +124,7 @@ def generate_user_instance(
         email = '%s@localhost' % (email,)
 
     if password is None:
-        password = _generate_salt(128)
+        password = security.generate_random(128)
 
     user_instance = User(
         guid=user_guid,


### PR DESCRIPTION
Removed xkcd passwd as suggested and done some rework on the random password etc generation.
Moved random value generation into extensions/auth/security.py (as it didn't fit cleanly in any module) 
Removed the random password setting from users set_password (this should be where it's set, not created), now raises an exception if password is NONE. 
set_password only currently called when password is not NONE. Expect there to be a reset_password function in future that calls this but password validation would be it's job.
User resources no longer generates a random password if there is none, it returns a BAD_REQUEST HTTP error code. Unit test added for this. 